### PR TITLE
#3 - Added request mocking framework to client

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,9 @@ scenario that they wish for you to implement using some existing functionality a
 ## Instructions
 
 1. Clone the project in your preferred IDE.
-2. Create a new branch in the format of `<yyyy-mm-dd>_<your name>` e.g. `2021-02-02_rick_hunter`
 3. Ensure that you have received the scenario that the interviewers wish to see you implement
 4. Share your screen so that the interviewers can see you working.
-5. Solve the scenario provided in a manner that you would usually do in a work environment, and push your branch 
-to GitHub when done.
+5. Solve the scenario provided in a manner that you would usually do in a work environment.
 
 ## Startup
 The following subheadings describe how to start the application for each 

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3343,6 +3343,24 @@
         "follow-redirects": "^1.10.0"
       }
     },
+    "axios-mock-adapter": {
+      "version": "1.19.0",
+      "resolved": "http://build-nexus.corp.globoforce.com:8081/nexus/content/groups/npm-gf-all/axios-mock-adapter/-/axios-mock-adapter-1.19.0.tgz",
+      "integrity": "sha512-D+0U4LNPr7WroiBDvWilzTMYPYTuZlbo6BI8YHZtj7wYQS8NkARlP9KBt8IWWHTQJ0q/8oZ0ClPBtKCCkx8cQg==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.3",
+        "is-buffer": "^2.0.3"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.5",
+          "resolved": "http://build-nexus.corp.globoforce.com:8081/nexus/content/groups/npm-gf-all/is-buffer/-/is-buffer-2.0.5.tgz",
+          "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+          "dev": true
+        }
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "http://build-nexus.corp.globoforce.com:8081/nexus/content/groups/npm-gf-all/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -4580,6 +4598,152 @@
         }
       }
     },
+    "concurrently": {
+      "version": "6.0.0",
+      "resolved": "http://build-nexus.corp.globoforce.com:8081/nexus/content/groups/npm-gf-all/concurrently/-/concurrently-6.0.0.tgz",
+      "integrity": "sha512-Ik9Igqnef2ONLjN2o/OVx1Ow5tymVvvEwQeYCQdD/oV+CN9oWhxLk7ibcBdOtv0UzBqHCEKRwbKceYoTK8t3fQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "date-fns": "^2.16.1",
+        "lodash": "^4.17.20",
+        "read-pkg": "^5.2.0",
+        "rxjs": "^6.6.3",
+        "spawn-command": "^0.0.2-1",
+        "supports-color": "^8.1.0",
+        "tree-kill": "^1.2.2",
+        "yargs": "^16.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "http://build-nexus.corp.globoforce.com:8081/nexus/content/groups/npm-gf-all/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "http://build-nexus.corp.globoforce.com:8081/nexus/content/groups/npm-gf-all/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "7.2.0",
+              "resolved": "http://build-nexus.corp.globoforce.com:8081/nexus/content/groups/npm-gf-all/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
+          }
+        },
+        "cliui": {
+          "version": "7.0.4",
+          "resolved": "http://build-nexus.corp.globoforce.com:8081/nexus/content/groups/npm-gf-all/cliui/-/cliui-7.0.4.tgz",
+          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://build-nexus.corp.globoforce.com:8081/nexus/content/groups/npm-gf-all/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://build-nexus.corp.globoforce.com:8081/nexus/content/groups/npm-gf-all/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://build-nexus.corp.globoforce.com:8081/nexus/content/groups/npm-gf-all/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "5.2.0",
+          "resolved": "http://build-nexus.corp.globoforce.com:8081/nexus/content/groups/npm-gf-all/read-pkg/-/read-pkg-5.2.0.tgz",
+          "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+          "dev": true,
+          "requires": {
+            "@types/normalize-package-data": "^2.4.0",
+            "normalize-package-data": "^2.5.0",
+            "parse-json": "^5.0.0",
+            "type-fest": "^0.6.0"
+          }
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "http://build-nexus.corp.globoforce.com:8081/nexus/content/groups/npm-gf-all/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "type-fest": {
+          "version": "0.6.0",
+          "resolved": "http://build-nexus.corp.globoforce.com:8081/nexus/content/groups/npm-gf-all/type-fest/-/type-fest-0.6.0.tgz",
+          "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "http://build-nexus.corp.globoforce.com:8081/nexus/content/groups/npm-gf-all/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "5.0.5",
+          "resolved": "http://build-nexus.corp.globoforce.com:8081/nexus/content/groups/npm-gf-all/y18n/-/y18n-5.0.5.tgz",
+          "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "16.2.0",
+          "resolved": "http://build-nexus.corp.globoforce.com:8081/nexus/content/groups/npm-gf-all/yargs/-/yargs-16.2.0.tgz",
+          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.6",
+          "resolved": "http://build-nexus.corp.globoforce.com:8081/nexus/content/groups/npm-gf-all/yargs-parser/-/yargs-parser-20.2.6.tgz",
+          "integrity": "sha512-AP1+fQIWSM/sMiET8fyayjx/J+JmTPt2Mr0FkrgqB4todtfa53sOsrSAcIrJRD5XS20bKUwaDIuMkWKCEiQLKA==",
+          "dev": true
+        }
+      }
+    },
     "confusing-browser-globals": {
       "version": "1.0.10",
       "resolved": "http://build-nexus.corp.globoforce.com:8081/nexus/content/groups/npm-gf-all/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
@@ -4746,6 +4910,58 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "http://build-nexus.corp.globoforce.com:8081/nexus/content/groups/npm-gf-all/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "http://build-nexus.corp.globoforce.com:8081/nexus/content/groups/npm-gf-all/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "http://build-nexus.corp.globoforce.com:8081/nexus/content/groups/npm-gf-all/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "http://build-nexus.corp.globoforce.com:8081/nexus/content/groups/npm-gf-all/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "http://build-nexus.corp.globoforce.com:8081/nexus/content/groups/npm-gf-all/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "http://build-nexus.corp.globoforce.com:8081/nexus/content/groups/npm-gf-all/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "cross-spawn": {
@@ -5142,6 +5358,12 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
+    },
+    "date-fns": {
+      "version": "2.18.0",
+      "resolved": "http://build-nexus.corp.globoforce.com:8081/nexus/content/groups/npm-gf-all/date-fns/-/date-fns-2.18.0.tgz",
+      "integrity": "sha512-NYyAg4wRmGVU4miKq5ivRACOODdZRY3q5WLmOJSq8djyzftYphU7dTHLcEtLqEvfqMKQ0jVv91P4BAwIjsXIcw==",
+      "dev": true
     },
     "debug": {
       "version": "4.3.1",
@@ -13617,6 +13839,15 @@
         "aproba": "^1.1.1"
       }
     },
+    "rxjs": {
+      "version": "6.6.6",
+      "resolved": "http://build-nexus.corp.globoforce.com:8081/nexus/content/groups/npm-gf-all/rxjs/-/rxjs-6.6.6.tgz",
+      "integrity": "sha512-/oTwee4N4iWzAMAL9xdGKjkEHmIwupR3oXbQjCKywF1BeFohswF3vZdogbmEF6pZkOsXTzWkrZszrWpQTByYVg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "http://build-nexus.corp.globoforce.com:8081/nexus/content/groups/npm-gf-all/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -14312,6 +14543,12 @@
       "version": "1.4.8",
       "resolved": "http://build-nexus.corp.globoforce.com:8081/nexus/content/groups/npm-gf-all/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+    },
+    "spawn-command": {
+      "version": "0.0.2-1",
+      "resolved": "http://build-nexus.corp.globoforce.com:8081/nexus/content/groups/npm-gf-all/spawn-command/-/spawn-command-0.0.2-1.tgz",
+      "integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=",
+      "dev": true
     },
     "spdx-correct": {
       "version": "3.1.1",
@@ -15128,6 +15365,12 @@
       "requires": {
         "punycode": "^2.1.1"
       }
+    },
+    "tree-kill": {
+      "version": "1.2.2",
+      "resolved": "http://build-nexus.corp.globoforce.com:8081/nexus/content/groups/npm-gf-all/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true
     },
     "tryer": {
       "version": "1.0.1",

--- a/client/package.json
+++ b/client/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "start": "react-scripts start",
+    "start:mock": "cross-env REACT_APP_USE_MOCKS=true react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
@@ -45,6 +46,8 @@
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.5",
     "@testing-library/user-event": "^12.8.3",
+    "axios-mock-adapter": "^1.19.0",
+    "cross-env": "^7.0.3",
     "prop-types": "^15.7.2"
   }
 }

--- a/client/src/Pages/Accounts/AccountList/AccountList.js
+++ b/client/src/Pages/Accounts/AccountList/AccountList.js
@@ -46,13 +46,13 @@ const columns = [
             </div>
         )
     }
-
 ];
 
 function AccountList(props) {
     return (
         <div style={{ height: 400, width: '100%' }}>
             <DataGrid
+                rowsPerPageOptions={[5, 10, 25, 50, 100]}
                 rows={props.accountData}
                 columns={columns}
                 pageSize={5}

--- a/client/src/Pages/Accounts/Accounts.js
+++ b/client/src/Pages/Accounts/Accounts.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { AccountsModel } from "./Accounts.model";
+import { getAllAccounts } from "./Accounts.model";
 import AccountList from "./AccountList/AccountList";
 
 function Accounts() {
@@ -7,7 +7,7 @@ function Accounts() {
 
     useEffect(() => {
         const fetchData = async () => {
-            const result = await AccountsModel.get();
+            const result = await getAllAccounts();
             setData(result.data);
         }
         fetchData();

--- a/client/src/Pages/Accounts/Accounts.mock.js
+++ b/client/src/Pages/Accounts/Accounts.mock.js
@@ -1,0 +1,29 @@
+import MockAdapter from "axios-mock-adapter";
+
+const mockedAccounts = [
+    {
+        id: 1,
+        accountNumber: "123456",
+        accountName: "Current",
+        accountBalance: 123.45
+    },
+    {
+        id: 2,
+        accountNumber: "234567",
+        accountName: "Savings",
+        accountBalance: 1234.56
+    }
+]
+
+export const setupAccountsMock = (client) => {
+    const mock = new MockAdapter(client);
+
+    mock.onGet(new RegExp('/api/v1/account')).reply(
+        200,
+        mockedAccounts
+    );
+    mock.onGet(new RegExp('/api/v1/account/*')).reply(
+        200,
+        mockedAccounts[0]
+    )
+}

--- a/client/src/Pages/Accounts/Accounts.model.js
+++ b/client/src/Pages/Accounts/Accounts.model.js
@@ -1,9 +1,23 @@
 import axios from 'axios';
+import { setupAccountsMock } from "./Accounts.mock";
 
 const BASE_URL = 'http://localhost:8080/api/v1/account';
 
-export const AccountsModel = {
-    get() {
-        return axios.get(BASE_URL, {});
+const useMocks = process.env.REACT_APP_USE_MOCKS;
+
+const client = axios.create({
+        baseURL: BASE_URL
     }
-};
+);
+
+if (useMocks) {
+    setupAccountsMock(client);
+}
+
+export const getAllAccounts = () => {
+    return client.get(BASE_URL);
+}
+
+export const getAccount = (id) => {
+    return client.get(`/${id}`)
+}

--- a/client/src/Pages/Users/UserList/UserList.js
+++ b/client/src/Pages/Users/UserList/UserList.js
@@ -54,6 +54,7 @@ function UserList(props) {
     return (
         <div style={{height: 400, width: '100%'}}>
             <DataGrid
+                rowsPerPageOptions={[5, 10, 25, 50, 100]}
                 rows={props.userData}
                 columns={columns}
                 pageSize={5}

--- a/client/src/Pages/Users/Users.js
+++ b/client/src/Pages/Users/Users.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { UsersModel } from "./Users.model";
+import { getAllUsers } from "./Users.model";
 import UserList from "./UserList/UserList";
 
 function Users() {
@@ -7,7 +7,7 @@ function Users() {
 
     useEffect(() => {
         const fetchData = async () => {
-            const result = await UsersModel.get();
+            const result = await getAllUsers();
             setData(result.data);
         }
         fetchData();

--- a/client/src/Pages/Users/Users.mock.js
+++ b/client/src/Pages/Users/Users.mock.js
@@ -1,0 +1,33 @@
+import MockAdapter from "axios-mock-adapter";
+
+const mockedUsers = [
+    {
+        id: 1,
+        userName: "one.person",
+        firstName: "One",
+        lastName: "Person",
+        email: "one.person@workhuman.com",
+        password: "p@ssw0rd"
+    },
+    {
+        id: 2,
+        userName: "two.person",
+        firstName: "Two",
+        lastName: "Person",
+        email: "two.person@workhuman.com",
+        password: "p@ssw0rd"
+    }
+]
+
+export const setupUsersMock = (client) => {
+    const mock = new MockAdapter(client);
+
+    mock.onGet(new RegExp('/api/v1/user')).reply(
+        200,
+        mockedUsers
+    );
+    mock.onGet(new RegExp('/api/v1/user/*')).reply(
+        200,
+        mockedUsers[0]
+    )
+}

--- a/client/src/Pages/Users/Users.model.js
+++ b/client/src/Pages/Users/Users.model.js
@@ -1,9 +1,24 @@
 import axios from 'axios';
+import { setupUsersMock } from "./Users.mock";
 
 const BASE_URL = 'http://localhost:8080/api/v1/user';
 
-export const UsersModel = {
-    get() {
-        return axios.get(BASE_URL, {});
+const useMocks = process.env.REACT_APP_USE_MOCKS;
+
+const client = axios.create({
+        baseURL: BASE_URL
     }
-};
+);
+
+if (useMocks) {
+    setupUsersMock(client);
+}
+
+export const getAllUsers = () => {
+    return client.get(BASE_URL);
+}
+
+export const getUser = (id) => {
+    return client.get(`/${id}`)
+}
+

--- a/client/src/setupTests.js
+++ b/client/src/setupTests.js
@@ -1,5 +1,0 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom';

--- a/server/src/main/resources/import.sql
+++ b/server/src/main/resources/import.sql
@@ -1,5 +1,5 @@
 INSERT INTO user (user_id, user_user_name, user_first_name, user_last_name, user_email, user_password, user_created_date, user_updated_date) VALUES (1, 'one.person', 'One', 'Person', 'one.person@workhuman.com', 'P@ssw0rd', CURRENT_DATE, CURRENT_DATE);
 INSERT INTO user (user_id, user_user_name, user_first_name, user_last_name, user_email, user_password, user_created_date, user_updated_date) VALUES (2, 'one.person', 'Two', 'Person', 'two.person@workhuman.com', 'P@ssw0rd', CURRENT_DATE, CURRENT_DATE);
 
-INSERT INTO account (account_number, account_name, account_balance, account_created_date, account_updated_date, account_user_id) VALUES ('123456', 'Current', 123.45, CURRENT_DATE, CURRENT_DATE, 1);
-INSERT INTO account (account_number, account_name, account_balance, account_created_date, account_updated_date, account_user_id) VALUES ('654321', 'Savings', 1234.56, CURRENT_DATE, CURRENT_DATE, 1);
+INSERT INTO account (account_number, account_name, account_balance, account_created_date, account_updated_date, account_user_id) VALUES ('123456', 'One Person Banking', 123.45, CURRENT_DATE, CURRENT_DATE, 1);
+INSERT INTO account (account_number, account_name, account_balance, account_created_date, account_updated_date, account_user_id) VALUES ('654321', 'One Person Savings', 1234.56, CURRENT_DATE, CURRENT_DATE, 1);


### PR DESCRIPTION
* Needed to add in the ability to add in a client-side mocking framework to allow for front-end only candidates to mock a response from the server. This is invoked by using the following command `npm run start:mock`
* Updated the account name for the demo data to make it clear that it's just a name.
* Changed the README to remove the requirement to create a branch. This would give candidates insight into what has been done previously by other candidates, and would require us to remove these branches each time.

Closes #3